### PR TITLE
Finish up CPAK Testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,4 +9,4 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - run: sudo apt install -y bzip2 pbzip2 rar unrar
-      - run: PATH="$PATH:${{ github.workspace }}/bin"; batman test/*
+      - run: PATH="$PATH:${{ github.workspace }}/bin"; make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	@bin/batman 'test/**'
+
+.PHONY: test

--- a/bin/batman
+++ b/bin/batman
@@ -6,13 +6,19 @@ source "$CSCRIPT_LIB/batlib.sh"
 plaintext=false
 show_usage=false
 
-while getopts "ph" opt; do
+while getopts "pht:v" opt; do
     case $opt in
         p)
             plaintext=true
             ;;
         h)
             show_usage=true
+            ;;
+        t)
+            TARGET_TEST="$OPTARG"
+            ;;
+        v)
+            VERBOSE=true
             ;;
         *)  ;;
     esac
@@ -28,15 +34,25 @@ if $show_usage; then
     exit 0
 fi
 
-for p in "$@"; do
-    RUN_PATHS+=("${p// /$CSCRIPT_SPACE_ENCODE}")
-done
+first_arg="$1"
+if [[ "$first_arg" == *"/**" ]]; then
+    OIFS="$IFS"
+    IFS=$(echo -en "\n\b")
+    for f in $(find $first_arg | grep "_test.sh" | sort | uniq); do
+        echo "f=$f"
+        [ -f "$f" ] && RUN_PATHS+=("${f// /$CSCRIPT_SPACE_ENCODE}")
+    done
+    IFS="$OIFS"
+else
+    for p in "$@"; do
+        [ -f "$p" ] && RUN_PATHS+=("${p// /$CSCRIPT_SPACE_ENCODE}")
+    done
+fi
 
 bat_banner
 
 if $plaintext; then
     (bat_run_tests; bat_summary) | unfancy
-    # bat_summary | unfancy
 else
     bat_run_tests
     bat_summary

--- a/lib/batlib.sh
+++ b/lib/batlib.sh
@@ -2,6 +2,8 @@
 
 source "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/configure.sh"
 
+TARGET_TEST=""
+VERBOSE=false
 BAT_STATUS=0
 
 SUITE_NAME=""
@@ -51,7 +53,7 @@ bat_valid_test() {
     local path="$@"
     local status=0
     grep -qE "run_test .* .*" "$path"; status=$((status + $?))
-    grep -qE "case_pass$" "$path"; status=$((status + $?))
+    # grep -qE "case_pass$" "$path"; status=$((status + $?))
 
     return $status
 }
@@ -98,13 +100,17 @@ start_suite() {
 }
 
 run_test() {
-    TEST_COUNT=$((TEST_COUNT + 1))
-    TEST_STATUS=0
-
     local test_func="$1"
     local name="$2"
 
-    fancy_print -n -s bold -c cyan "Running: "
+    if [[ "$TARGET_TEST" != "" ]] && [[ "${test_func^^}" != *"${TARGET_TEST^^}"* ]]; then
+        return 0
+    fi
+
+    TEST_COUNT=$((TEST_COUNT + 1))
+    TEST_STATUS=0
+
+    fancy_print -n -s bold -c cyan "Running[$test_func]: "
     fancy_print -s bold "$name"
 
     "$test_func"
@@ -117,6 +123,7 @@ run_test() {
     fi
 
     echo ""
+    return "$TEST_STATUS"
 }
 
 case_set() {

--- a/lib/configure.sh
+++ b/lib/configure.sh
@@ -2,6 +2,7 @@
 
 CSCRIPT_LIB="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 CSCRIPT_DIR="$( cd $CSCRIPT_LIB/.. && pwd )"
+CSCRIPT_TEST="$( cd $CSCRIPT_DIR/test && pwd )"
 CSCRIPT_SPACE_ENCODE="@%@%"
 CSCRIPT_VAR_ENCODE_START="@@{"
 CSCRIPT_VAR_ENCODE_END="}@@"

--- a/lib/cpak_methods.sh
+++ b/lib/cpak_methods.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-#TODO: If in sequential mode, decompressions should always multi-thread when available
-
 __decode_filename() {
     local encoded_file="$1"
     echo "${encoded_file//$CSCRIPT_SPACE_ENCODE/\ }"
@@ -40,13 +38,17 @@ __unpack_with_move() {
     local output="$2"
     local cmd="$3"
     local new_location="."
+    local og_location="$(pwd)"
 
     if [ "$output" != "" ] && [ -d "$output" ]; then
         mv "$file" "$output"
         new_location="$output"
     fi
 
-    pushd . && cd $new_location && eval "$cmd" && popd
+    pushd . $>/dev/null
+    cd $new_location
+    eval "$cmd"
+    popd
 }
 
 # 7z

--- a/test/cpak/cpak_batch_pack.sh
+++ b/test/cpak/cpak_batch_pack.sh
@@ -1,0 +1,96 @@
+cpak_batch_pack_case() {
+    local pack_type="$1"
+    local output_dir="$TEST_DIR/working"
+    local file_base="$2"
+    local pack_output="test_package"
+    local expected_file_count=5
+
+    cd "$TEST_DIR"
+
+    local i=0
+    while [ "$i" -lt "$expected_file_count" ]; do
+        echo "hello" > "${file}${i}.test"
+        i=$((i + 1))
+    done
+
+    # Pack
+    if $VERBOSE; then
+        bash $CSCRIPT_DIR/bin/cpak p -v -t $pack_type -o $pack_output "$TEST_DIR/*.test"
+        local status_code="$?"
+    else
+        bash $CSCRIPT_DIR/bin/cpak p -t $pack_type -o $pack_output "$TEST_DIR/*.test" &>/dev/null
+        local status_code="$?"
+    fi
+
+    if [ $status_code -eq 1 ]; then
+        case_fail "Unknown error during packing procedure"
+        return 1
+    fi
+    
+    if [ ! -f "$pack_output.$pack_type" ]; then
+        case_fail "Missing packed file"
+        return 1
+    fi
+
+    # Unpack
+    if $VERBOSE; then
+        bash $CSCRIPT_DIR/bin/cpak u -v -o "$output_dir" "$pack_output.$pack_type"
+        status_code="$?"
+    else
+        bash $CSCRIPT_DIR/bin/cpak u -o "$output_dir" "$pack_output.$pack_type" &>/dev/null
+        status_code="$?"
+    fi
+
+    if [ $status_code -eq 1 ]; then
+        case_fail "Unknown error during packing procedure"
+        return 1
+    else
+        local checked_file_count=0
+        for f in "$output_dir"/*.test; do
+            file_content=$(cat "$f")
+
+            if [[ "$file_content" != "hello" ]]; then
+                case_fail "Unexpected unpacked file contents. Expected=hello, Actual=$file_content"
+                return 1
+            fi
+
+            checked_file_count=$((checked_file_count + 1))
+        done
+
+        if [[ "$checked_file_count" != "$expected_file_count" ]]; then
+            case_fail "Incorrect number of unpacked files. Expected=$expected_file_count, Actual=$checked_file_count"
+            return 1
+        fi
+    fi
+
+    case_pass
+
+    [ -f "$file" ] && rm "$file"
+    [ -d "$output_dir" ] && rm -r "$output_dir"
+
+    return 0
+}
+
+cpak_batch_pack_test() {
+    local test_cases=(
+        "7z;testfile" 
+        "rar;testfile"
+        "tar;testfile"
+        "tar.bz2;testfile"
+        "tar.gz;testfile"
+        "tar.xz;testfile"
+        "zip;testfile"
+    )
+
+    for tc_def in "${test_cases[@]}"; do
+        tc=(${tc_def//;/ })
+        cmd="${tc[0]}"
+        file="${tc[1]}"
+        match_og="${tc[2]}"
+
+        case_set "$cmd"
+        cpak_batch_pack_case "$cmd" "$file" "$match_og"
+
+        [ -d "$output" ] && rm -r "$output"
+    done
+}

--- a/test/cpak/cpak_batch_unpack.sh
+++ b/test/cpak/cpak_batch_unpack.sh
@@ -1,0 +1,98 @@
+cpak_batch_unpack_case() {
+    local pack_type="$1"
+    local output_dir="$TEST_DIR/working"
+    local file_base="$2"
+    local pack_output="test_package"
+    local expected_file_count=5
+
+    cd "$TEST_DIR"
+
+    local i=0
+    while [ "$i" -lt "$expected_file_count" ]; do
+        echo "hello" > "${file}${i}.test"
+        i=$((i + 1))
+    done
+
+    # Pack
+    for f in "$output_dir"/*.test; do
+        if $VERBOSE; then
+            bash $CSCRIPT_DIR/bin/cpak p -v -t $pack_type -o $pack_output "$f"
+            local status_code="$?"
+        else
+            bash $CSCRIPT_DIR/bin/cpak p -t $pack_type -o $pack_output "$f" &>/dev/null
+            local status_code="$?"
+        fi
+    done
+
+    if [ $status_code -eq 1 ]; then
+        case_fail "Unknown error during packing procedure"
+        return 1
+    fi
+    
+    if [ ! -f "$pack_output.$pack_type" ]; then
+        case_fail "Missing packed file"
+        return 1
+    fi
+
+    # Unpack
+    if $VERBOSE; then
+        bash $CSCRIPT_DIR/bin/cpak u -v -o "$output_dir" "$pack_output.$pack_type"
+        status_code="$?"
+    else
+        bash $CSCRIPT_DIR/bin/cpak u -o "$output_dir" "$pack_output.$pack_type" &>/dev/null
+        status_code="$?"
+    fi
+
+    if [ $status_code -eq 1 ]; then
+        case_fail "Unknown error during packing procedure"
+        return 1
+    else
+        local checked_file_count=0
+        for f in "$output_dir"/*.test; do
+            file_content=$(cat "$f")
+
+            if [[ "$file_content" != "hello" ]]; then
+                case_fail "Unexpected unpacked file contents. Expected=hello, Actual=$file_content"
+                return 1
+            fi
+
+            checked_file_count=$((checked_file_count + 1))
+        done
+
+        if [[ "$checked_file_count" != "$expected_file_count" ]]; then
+            case_fail "Incorrect number of unpacked files. Expected=$expected_file_count, Actual=$checked_file_count"
+            return 1
+        fi
+    fi
+
+    case_pass
+
+    [ -f "$file" ] && rm "$file"
+    [ -d "$output_dir" ] && rm -r "$output_dir"
+
+    return 0
+}
+
+cpak_batch_unpack_test() {
+    local test_cases=(
+        "7z;testfile;true" 
+        "rar;testfile;true"
+        "tar;testfile;true"
+        "tar.bz2;testfile;true"
+        "tar.gz;testfile;true"
+        "tar.xz;testfile;true"
+        "zip;testfile;true"
+    )
+
+    for tc_def in "${test_cases[@]}"; do
+        tc=(${tc_def//;/ })
+        cmd="${tc[0]}"
+        file="${tc[1]}"
+        match_og="${tc[2]}"
+
+        case_set "$cmd"
+        cpak_batch_pack_case "$cmd" "$file" "$match_og"
+
+        [ -d "$output" ] && rm -r "$output"
+    done
+}

--- a/test/cpak/cpak_single.sh
+++ b/test/cpak/cpak_single.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-TEST_DIR="/tmp"
-
-run_single_case() {
+cpak_single_case() {
     local pack_type="$1"
     local output_dir="$TEST_DIR/working"
     local file="$2"
@@ -72,10 +70,8 @@ cpak_single_test() {
         match_og="${tc[2]}"
 
         case_set "$cmd"
-        run_single_case "$cmd" "$file" "$match_og"
+        cpak_single_case "$cmd" "$file" "$match_og"
 
         [ -d "$output" ] && rm -r "$output"
     done
 }
-
-run_test "cpak_single_test" "Pack and Unpack (Single File)"

--- a/test/cpak/cpak_test.sh
+++ b/test/cpak/cpak_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+source "$CSCRIPT_TEST/cpak/cpak_single.sh"
+source "$CSCRIPT_TEST/cpak/cpak_batch_pack.sh"
+source "$CSCRIPT_TEST/cpak/cpak_batch_unpack.sh"
+
+TEST_DIR="/tmp"
+
+run_test "cpak_single_test" "Pack and unpack a file (Single)"
+run_test "cpak_batch_pack_test" "Pack many files into one archive (Batch)"
+run_test "cpak_batch_unpack_test" "Unpack many files (Batch)"


### PR DESCRIPTION
- New CPAK Tests - Packing multiple files into a single archive - Unpacking many archives

Bundled into this are some Batman changes to things that came up while working on on the CPAK tests.

    - Added -v flag to batman for verbose mode
      Scripts are responsible for determining what "verbose" means to
      them.
    - Removed case_pass check from batman script check.
      This came up when I realized that the CPAK tests would be better
      organized if split into different files.
    - Added a -t <filter> flag to Batman.
      Give a substring to Batman via -t to filter the tests executed.
    - Added support for /** pattern

Added a Makefile to run tests that always uses the "include" Batman version.